### PR TITLE
feat: Add search functionality to Bible reader

### DIFF
--- a/adamic/bible.py
+++ b/adamic/bible.py
@@ -24,3 +24,12 @@ class Bible:
 
     def get_books(self) -> list:
         return list(self.data.keys())
+
+    def search(self, keyword: str) -> list:
+        results = []
+        for book in self.data:
+            for chapter in self.data[book]:
+                for verse, text in self.data[book][chapter].items():
+                    if keyword.lower() in text.lower():
+                        results.append(f"{book} {chapter}:{verse}")
+        return results

--- a/app.py
+++ b/app.py
@@ -10,6 +10,10 @@ bible = Bible(data_path)
 def get_verse_text(book, chapter, verse):
     return bible.get_verse(book, chapter, verse)
 
+def search_bible(keyword):
+    results = bible.search(keyword)
+    return "\n".join(results) if results else "No results found."
+
 def ai_query(question):
     return get_ai_response(question)
 
@@ -17,18 +21,28 @@ with gr.Blocks() as demo:
     gr.Markdown("# Adamic Bible Reader")
 
     with gr.Tab("Reader"):
+        gr.Markdown("### Verse Lookup")
         with gr.Row():
             book_dropdown = gr.Dropdown(bible.get_books(), label="Book")
             chapter_input = gr.Number(label="Chapter", precision=0)
             verse_input = gr.Number(label="Verse", precision=0)
-
         output_text = gr.Textbox(label="Verse Text")
-
         load_button = gr.Button("Load Verse")
         load_button.click(
             get_verse_text,
             inputs=[book_dropdown, chapter_input, verse_input],
             outputs=output_text,
+        )
+
+        gr.Markdown("---")
+        gr.Markdown("### Keyword Search")
+        search_input = gr.Textbox(label="Enter keyword")
+        search_output = gr.Textbox(label="Search Results")
+        search_button = gr.Button("Search")
+        search_button.click(
+            search_bible,
+            inputs=search_input,
+            outputs=search_output,
         )
 
     with gr.Tab("AI Assistant"):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,26 @@
+import pytest
+from pathlib import Path
+from adamic.bible import Bible
+
+@pytest.fixture
+def bible():
+    data_path = Path(__file__).parent.parent / "adamic" / "data" / "sample_bible.json"
+    return Bible(data_path)
+
+def test_search(bible):
+    results = bible.search("beginning")
+    assert "Genesis 1:1" in results
+    assert "John 1:1" in results
+    assert "John 1:2" in results
+    assert len(results) == 3
+
+def test_search_case_insensitive(bible):
+    results = bible.search("BEGINNING")
+    assert "Genesis 1:1" in results
+    assert "John 1:1" in results
+    assert "John 1:2" in results
+    assert len(results) == 3
+
+def test_search_no_results(bible):
+    results = bible.search("nonexistent")
+    assert len(results) == 0


### PR DESCRIPTION
This commit introduces a new search feature to the Adamic Bible Reader.

- A `search(keyword)` method has been added to the `adamic.bible.Bible` class to find verses matching a given keyword.
- The user interface in `app.py` has been updated with a search box and a results display area under the "Reader" tab.
- Unit tests have been added in `tests/test_search.py` to verify the correctness of the search method, including case-insensitivity and handling of no results.
- The project is now installable in editable mode, which resolves test import errors.