### PR TITLE
Add badge tracking and display

### DIFF
--- a/adamic/logic/database.py
+++ b/adamic/logic/database.py
@@ -1,10 +1,11 @@
+import json
 import sqlite3
 from pathlib import Path
-from typing import Optional
+from typing import List
 
 
 class Database:
-    """Simple SQLite-based storage for user experience points."""
+    """Simple SQLite-based storage for user profiles and experience points."""
 
     def __init__(self, path: Path):
         self.path = Path(path)
@@ -19,7 +20,16 @@ class Database:
                 user_id TEXT PRIMARY KEY,
                 points INTEGER NOT NULL
             )
+            """,
+        )
+        cur.execute(
             """
+            CREATE TABLE IF NOT EXISTS profile (
+                user_id TEXT PRIMARY KEY,
+                verses_read INTEGER NOT NULL,
+                badges TEXT NOT NULL
+            )
+            """,
         )
         self.conn.commit()
 
@@ -46,6 +56,58 @@ class Database:
         new_total = current + delta
         self.set_xp(user_id, new_total)
         return new_total
+
+    # Profile helpers
+    def _ensure_profile(self, user_id: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO profile (user_id, verses_read, badges)
+            VALUES (?, 0, ?)
+            """,
+            (user_id, json.dumps([])),
+        )
+        self.conn.commit()
+
+    def get_verses_read(self, user_id: str) -> int:
+        self._ensure_profile(user_id)
+        cur = self.conn.cursor()
+        cur.execute("SELECT verses_read FROM profile WHERE user_id=?", (user_id,))
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+    def increment_verses_read(self, user_id: str, delta: int) -> int:
+        current = self.get_verses_read(user_id)
+        new_total = current + delta
+        cur = self.conn.cursor()
+        cur.execute(
+            "UPDATE profile SET verses_read=? WHERE user_id=?",
+            (new_total, user_id),
+        )
+        self.conn.commit()
+        return new_total
+
+    def get_badges(self, user_id: str) -> List[str]:
+        self._ensure_profile(user_id)
+        cur = self.conn.cursor()
+        cur.execute("SELECT badges FROM profile WHERE user_id=?", (user_id,))
+        row = cur.fetchone()
+        if not row:
+            return []
+        badges = json.loads(row[0])
+        return list(badges)
+
+    def add_badge(self, user_id: str, badge: str) -> List[str]:
+        badges = self.get_badges(user_id)
+        if badge not in badges:
+            badges.append(badge)
+            cur = self.conn.cursor()
+            cur.execute(
+                "UPDATE profile SET badges=? WHERE user_id=?",
+                (json.dumps(badges), user_id),
+            )
+            self.conn.commit()
+        return badges
 
     def close(self) -> None:
         self.conn.close()

--- a/app.py
+++ b/app.py
@@ -16,10 +16,17 @@ xp_manager = XPManager(database)
 USER_ID = "default"
 
 
+def badges_text(user_id: str) -> str:
+    badges = xp_manager.get_badges(user_id)
+    if badges:
+        return f"User: {user_id} | Badges: {', '.join(badges)}"
+    return f"User: {user_id}"
+
+
 def view_verse(book, chapter, verse):
     text = bible.get_verse(book, chapter, verse)
     xp = xp_manager.award_verse_view(USER_ID)
-    return text, xp
+    return text, xp, badges_text(USER_ID)
 
 def search_bible(keyword):
     results = bible.search(keyword)
@@ -33,6 +40,7 @@ def ai_query(question, timeout):
 
 with gr.Blocks() as demo:
     gr.Markdown("# Adamic Bible Reader")
+    user_badges_display = gr.Markdown(badges_text(USER_ID))
 
     with gr.Tab("Reader"):
         gr.Markdown("### Verse Lookup")
@@ -50,7 +58,7 @@ with gr.Blocks() as demo:
         load_button.click(
             view_verse,
             inputs=[book_dropdown, chapter_input, verse_input],
-            outputs=[output_text, xp_display],
+            outputs=[output_text, xp_display, user_badges_display],
         )
 
         gr.Markdown("---")

--- a/tests/test_xp_manager.py
+++ b/tests/test_xp_manager.py
@@ -35,3 +35,14 @@ def test_persistence(tmp_path):
     db2 = Database(db_path)
     manager2 = XPManager(db2)
     assert manager2.get_xp(user) == 1
+
+
+def test_badge_awarded(tmp_path):
+    db = Database(tmp_path / "xp.db")
+    manager = XPManager(db)
+    user = "carol"
+    for _ in range(100):
+        manager.award_verse_view(user)
+    assert manager.get_verses_read(user) == 100
+    assert "100 Verses" in manager.get_badges(user)
+


### PR DESCRIPTION
## Summary
- track verses read and badges in a new user profile table
- award badges when verse count meets thresholds
- show user badges beside the username in the Gradio UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cf1269fd0833189c38013e691b5a1