### PR TITLE
Add passage rating system influencing XP bonuses

### DIFF
--- a/adamic/logic/database.py
+++ b/adamic/logic/database.py
@@ -1,10 +1,10 @@
 import sqlite3
 from pathlib import Path
-from typing import Optional
+
 
 
 class Database:
-    """Simple SQLite-based storage for user experience points."""
+    """Simple SQLite-based storage for user experience points and ratings."""
 
     def __init__(self, path: Path):
         self.path = Path(path)
@@ -18,6 +18,16 @@ class Database:
             CREATE TABLE IF NOT EXISTS xp (
                 user_id TEXT PRIMARY KEY,
                 points INTEGER NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ratings (
+                user_id TEXT,
+                passage TEXT,
+                rating INTEGER NOT NULL,
+                PRIMARY KEY (user_id, passage)
             )
             """
         )
@@ -46,6 +56,26 @@ class Database:
         new_total = current + delta
         self.set_xp(user_id, new_total)
         return new_total
+
+    # Rating helpers
+    def set_rating(self, user_id: str, passage: str, rating: int) -> float:
+        """Store a user's rating for a passage and return new average rating."""
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO ratings (user_id, passage, rating) VALUES (?, ?, ?)
+            ON CONFLICT(user_id, passage) DO UPDATE SET rating=excluded.rating
+            """,
+            (user_id, passage, rating),
+        )
+        self.conn.commit()
+        return self.get_average_rating(passage)
+
+    def get_average_rating(self, passage: str) -> float:
+        cur = self.conn.cursor()
+        cur.execute("SELECT AVG(rating) FROM ratings WHERE passage=?", (passage,))
+        row = cur.fetchone()
+        return float(row[0]) if row and row[0] is not None else 0.0
 
     def close(self) -> None:
         self.conn.close()

--- a/app.py
+++ b/app.py
@@ -16,10 +16,22 @@ xp_manager = XPManager(database)
 USER_ID = "default"
 
 
+def _format_passage(book, chapter, verse):
+    return f"{book} {int(chapter)}:{int(verse)}"
+
+
 def view_verse(book, chapter, verse):
+    passage = _format_passage(book, chapter, verse)
     text = bible.get_verse(book, chapter, verse)
-    xp = xp_manager.award_verse_view(USER_ID)
-    return text, xp
+    xp = xp_manager.award_verse_view(USER_ID, passage)
+    avg = database.get_average_rating(passage)
+    return text, xp, avg
+
+
+def rate_passage(book, chapter, verse, rating):
+    passage = _format_passage(book, chapter, verse)
+    avg, xp = xp_manager.submit_rating(USER_ID, passage, int(rating))
+    return avg, xp
 
 def search_bible(keyword):
     results = bible.search(keyword)
@@ -41,16 +53,20 @@ with gr.Blocks() as demo:
             chapter_input = gr.Number(label="Chapter", precision=0)
             verse_input = gr.Number(label="Verse", precision=0)
         output_text = gr.Textbox(label="Verse Text")
-        xp_display = gr.Number(
-            label="Current XP",
-            value=xp_manager.get_xp(USER_ID),
-            interactive=False,
-        )
+        xp_display = gr.Number(label="Current XP", value=xp_manager.get_xp(USER_ID), interactive=False)
+        avg_display = gr.Number(label="Average Rating", value=0, interactive=False)
         load_button = gr.Button("Load Verse")
         load_button.click(
             view_verse,
             inputs=[book_dropdown, chapter_input, verse_input],
-            outputs=[output_text, xp_display],
+            outputs=[output_text, xp_display, avg_display],
+        )
+        rating_slider = gr.Slider(1, 5, step=1, label="Your Rating")
+        rate_button = gr.Button("Submit Rating")
+        rate_button.click(
+            rate_passage,
+            inputs=[book_dropdown, chapter_input, verse_input, rating_slider],
+            outputs=[avg_display, xp_display],
         )
 
         gr.Markdown("---")

--- a/tests/test_xp_manager.py
+++ b/tests/test_xp_manager.py
@@ -35,3 +35,18 @@ def test_persistence(tmp_path):
     db2 = Database(db_path)
     manager2 = XPManager(db2)
     assert manager2.get_xp(user) == 1
+
+
+def test_rating_influences_xp(tmp_path):
+    db = Database(tmp_path / "xp.db")
+    manager = XPManager(db)
+    passage = "Genesis 1:1"
+    user1 = "alice"
+    user2 = "bob"
+    manager.award_verse_view(user1, passage)
+    assert manager.get_xp(user1) == 1
+    avg, xp = manager.submit_rating(user2, passage, 4)
+    assert avg == 4
+    assert xp == 4
+    manager.award_verse_view(user1, passage)
+    assert manager.get_xp(user1) == 6


### PR DESCRIPTION
## Summary
- Add SQLite `ratings` table and helpers for storing and averaging user passage ratings
- Factor average ratings into verse XP and award bonuses when users submit ratings
- Extend reader UI with rating controls and average rating display; tests cover rating impact on XP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689cf12b00908331931cf2d02d8cd23b